### PR TITLE
delete glob before installing sub to fix 5.8.9 issue

### DIFF
--- a/lib/Git/Sub.pm
+++ b/lib/Git/Sub.pm
@@ -61,10 +61,11 @@ use subs
 sub AUTOLOAD
 {
     my $git_cmd = our $AUTOLOAD;
-    $git_cmd = substr($git_cmd, 1+rindex($git_cmd, ':'));
+    my $git_sub = $git_cmd = substr($git_cmd, 1+rindex($git_cmd, ':'));
     $git_cmd =~ tr/_/-/; # Seems to the first time I use tr// in the last 2 years
     $GIT ||= File::Which::which('git');
 
+    delete $git::{$git_sub};
     System::Sub->import($AUTOLOAD, [
 	'$0' => $GIT,
 	'@ARGV' => [ $git_cmd ],


### PR DESCRIPTION
In perl 5.8.9, predeclaring a sub can leave it in a broken state that
can't properly by replaced.  Delete the glob before installing the sub
to work around this.

Fixes [RT#118898](https://rt.cpan.org/Ticket/Display.html?id=118898).